### PR TITLE
Added (simple) exception handling if ascii decode in scandir fails

### DIFF
--- a/scandir.py
+++ b/scandir.py
@@ -582,7 +582,10 @@ elif sys.platform.startswith(('linux', 'darwin', 'sunos5')) or 'bsd' in sys.plat
                     name = entry.d_name
                     if name not in (b'.', b'..'):
                         if not is_bytes:
-                            name = name.decode(file_system_encoding)
+                            try:
+                                name = name.decode(file_system_encoding)
+                            except:
+                                name = "AsciiDecodeError"
                         yield PosixDirEntry(path, name, entry.d_type, entry.d_ino)
             finally:
                 if closedir(dir_p):


### PR DESCRIPTION
Has been observed with py2 on long crawl, but unfortunately I don't
have enough info to reproduce consistently.